### PR TITLE
Refactoring the answer property of the question

### DIFF
--- a/src/OnceUponATime/Application/AnswerQuestionHandler.php
+++ b/src/OnceUponATime/Application/AnswerQuestionHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OnceUponATime\Application;
 
+use OnceUponATime\Domain\Entity\Answer;
 use OnceUponATime\Domain\Entity\ExternalUserId;
 use OnceUponATime\Domain\Entity\Question;
 use OnceUponATime\Domain\Entity\QuestionAnswered;
@@ -80,8 +81,8 @@ class AnswerQuestionHandler
         return $question;
     }
 
-    private function getAnswer(AnswerQuestion $answerQuestion): ExternalUserId
+    private function getAnswer(AnswerQuestion $answerQuestion): Answer
     {
-        return ExternalUserId::fromString($answerQuestion->answer);
+        return Answer::fromString($answerQuestion->answer);
     }
 }

--- a/src/OnceUponATime/Domain/Entity/Answer.php
+++ b/src/OnceUponATime/Domain/Entity/Answer.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OnceUponATime\Domain\Entity;
+
+use Assert\Assertion;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class Answer
+{
+    /** @var ExternalUserId */
+    protected $externalUserId;
+
+    public static function fromString(string $id): Answer
+    {
+        Assertion::notEmpty($id);
+
+        $answer = new self();
+        $answer->externalUserId = ExternalUserId::fromString($id) ;
+
+        return $answer;
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->externalUserId;
+    }
+
+    public function equals($answer): bool
+    {
+        return $answer instanceof Answer &&
+            $this->externalUserId->equals($answer->externalUserId);
+    }
+}

--- a/src/OnceUponATime/Domain/Entity/Question.php
+++ b/src/OnceUponATime/Domain/Entity/Question.php
@@ -16,7 +16,7 @@ class Question
     /** @var Statement */
     private $statement;
 
-    /** @var ExternalUserId */
+    /** @var Answer */
     private $answer;
 
     /** @var Clue */
@@ -28,7 +28,7 @@ class Question
     public static function ask(
         QuestionId $questionId,
         Statement $statement,
-        ExternalUserId $answer,
+        Answer $answer,
         Clue $clue1,
         Clue $clue2
     ): Question {
@@ -47,7 +47,7 @@ class Question
         return $this->id;
     }
 
-    public function answer(): ExternalUserId
+    public function answer(): Answer
     {
         return $this->answer;
     }
@@ -62,7 +62,7 @@ class Question
         return $this->clue2;
     }
 
-    public function isCorrect(ExternalUserId $answer): bool
+    public function isCorrect(Answer $answer): bool
     {
         return $this->answer()->equals($answer);
     }

--- a/test/Acceptance/FeatureContext.php
+++ b/test/Acceptance/FeatureContext.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Tests\Acceptance;
 
 use Behat\Behat\Context\Context;
-use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Gherkin\Node\TableNode;
 use LogicException;
 use OnceUponATime\Application\AnswerQuestion;
 use OnceUponATime\Application\AnswerQuestionHandler;
+use OnceUponATime\Domain\Entity\Answer;
 use OnceUponATime\Domain\Entity\Clue;
 use OnceUponATime\Domain\Entity\ExternalUserId;
 use OnceUponATime\Domain\Entity\Name;
@@ -122,7 +122,7 @@ class FeatureContext implements Context
         return Question::ask(
             QuestionId::fromString($row['id']),
             Statement::fromString($row['statement']),
-            ExternalUserId::fromString($row['answer']),
+            Answer::fromString($row['answer']),
             Clue::FromString($row['clue1']),
             Clue::FromString($row['clue2'])
         );

--- a/test/Integration/OnceUponATime/Infrastructure/Persistence/InMemory/InMemoryQuestionRepositoryTest.php
+++ b/test/Integration/OnceUponATime/Infrastructure/Persistence/InMemory/InMemoryQuestionRepositoryTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Integration\OnceUponATime\Infrastructure\Persistence\InMemory;
 
+use OnceUponATime\Domain\Entity\Answer;
 use OnceUponATime\Domain\Entity\Clue;
 use OnceUponATime\Domain\Entity\Question;
 use OnceUponATime\Domain\Entity\QuestionId;
-use OnceUponATime\Domain\Entity\ExternalUserId;
 use OnceUponATime\Domain\Entity\Statement;
 use OnceUponATime\Infrastructure\Persistence\InMemory\InMemoryQuestionRepository;
 use PHPUnit\Framework\TestCase;
@@ -46,7 +46,7 @@ class InMemoryQuestionRepositoryTest extends TestCase
         $question = Question::ask(
             $questionId,
             Statement::fromString('What is the size of an elephant ?'),
-            ExternalUserId::fromString('<@U041UN08U>'),
+            Answer::fromString('<@U041UN08U>'),
             Clue::fromString('clue number one.'),
             Clue::fromString('clue number two.')
         );
@@ -66,7 +66,7 @@ class InMemoryQuestionRepositoryTest extends TestCase
         $question = Question::ask(
             $questionId,
             Statement::fromString('What is the size of an elephant ?'),
-            ExternalUserId::fromString('<@U041UN08U>'),
+            Answer::fromString('<@U041UN08U>'),
             Clue::fromString('clue number one.'),
             Clue::fromString('clue number two.')
         );
@@ -85,7 +85,7 @@ class InMemoryQuestionRepositoryTest extends TestCase
         $question1 = Question::ask(
             $questionId1,
             Statement::fromString('What is the size of an elephant ?'),
-            ExternalUserId::fromString('<@U041UN08U>'),
+            Answer::fromString('<@U041UN08U>'),
             Clue::fromString('clue number one.'),
             Clue::fromString('clue number two.')
         );
@@ -95,7 +95,7 @@ class InMemoryQuestionRepositoryTest extends TestCase
         $question2 = Question::ask(
             $questionId2,
             Statement::fromString('What is the size of an mouse ?'),
-            ExternalUserId::fromString('<@U041UN0812>'),
+            Answer::fromString('<@U041UN0812>'),
             Clue::fromString('clue number one.'),
             Clue::fromString('clue number two.')
         );

--- a/test/Unit/OnceUponATime/Application/AnswerQuestionHandlerTest.php
+++ b/test/Unit/OnceUponATime/Application/AnswerQuestionHandlerTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\OnceUponATime\Application\Entity;
 
 use OnceUponATime\Application\AnswerQuestion;
 use OnceUponATime\Application\AnswerQuestionHandler;
+use OnceUponATime\Domain\Entity\Answer;
 use OnceUponATime\Domain\Entity\Clue;
 use OnceUponATime\Domain\Entity\ExternalUserId;
 use OnceUponATime\Domain\Entity\Name;
@@ -35,7 +36,7 @@ class AnswerQuestionHandlerTest extends TestCase
         $question = Question::ask(
             QuestionId::fromString(self::QUESTION_ID),
             Statement::fromString('What is the most scared of an elephant ?'),
-            ExternalUserId::fromString('<@right_answer>'),
+            Answer::fromString('<@right_answer>'),
             Clue::fromString('Clue 1'),
             Clue::fromString('Clue 2')
         );

--- a/test/Unit/OnceUponATime/Domain/Entity/AnswerTest.php
+++ b/test/Unit/OnceUponATime/Domain/Entity/AnswerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Unit\OnceUponATime\Domain\Entity;
+
+use OnceUponATime\Domain\Entity\Answer;
+use PHPUnit\Framework\TestCase;
+
+class AnswerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_can_be_constructed_with_a_string()
+    {
+        $id = '<@U041UN08U>';
+        $externalUserId = Answer::fromString($id);
+        $this->assertSame($id, (string) $externalUserId);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_compared_to_another_answer()
+    {
+        $userId1 = Answer::fromString('<@U041UN08U>');
+        $userId2 = Answer::fromString('<@U041UN08U>');
+        $this->assertTrue($userId1->equals($userId2));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_be_an_non_empty_string()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Answer::fromString('');
+    }
+}

--- a/test/Unit/OnceUponATime/Domain/Entity/QuestionTest.php
+++ b/test/Unit/OnceUponATime/Domain/Entity/QuestionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\OnceUponATime\Domain\Entity;
 
+use OnceUponATime\Domain\Entity\Answer;
 use OnceUponATime\Domain\Entity\Clue;
 use OnceUponATime\Domain\Entity\Question;
 use OnceUponATime\Domain\Entity\QuestionId;
@@ -24,7 +25,7 @@ class QuestionTest extends TestCase
     {
         $questionId = QuestionId::fromString('3a021c08-ad15-43aa-aba3-8626fecd39a7');
         $statement = Statement::fromString('What is the size of an elephant ?');
-        $answer = ExternalUserId::fromString('<@U041UN08U>');
+        $answer = Answer::fromString('<@U041UN08U>');
         $clue1 = Clue::fromString('clue number one.');
         $clue2 = Clue::fromString('clue number two.');
 
@@ -44,14 +45,14 @@ class QuestionTest extends TestCase
     {
         $questionId = QuestionId::fromString('3a021c08-ad15-43aa-aba3-8626fecd39a7');
         $statement = Statement::fromString('What is the size of an elephant ?');
-        $answer = ExternalUserId::fromString('<@U041UN08U>');
+        $answer = Answer::fromString('<@U041UN08U>');
         $clue1 = Clue::fromString('clue number one.');
         $clue2 = Clue::fromString('clue number two.');
         $question = Question::ask($questionId, $statement, $answer, $clue1, $clue2);
 
-        $rightAnswer = ExternalUserId::fromString('<@U041UN08U>');
+        $rightAnswer = Answer::fromString('<@U041UN08U>');
         $this->assertTrue($question->isCorrect($rightAnswer));
-        $wrongAnswer = ExternalUserId::fromString('<@U041XXXXX>');
+        $wrongAnswer = Answer::fromString('<@U041XXXXX>');
         $this->assertFalse($question->isCorrect($wrongAnswer));
     }
 }


### PR DESCRIPTION
Before this PR, the answer of a question was an ExternalUserId (eg,
Slack user id).

This design led to some wierd code in the upper layer and is not very
future proof nor easy to understand.

So this PR introduces a proper 'Answer' object which has a
ExternalUserId property (it wraps an external user id really.).

All the code is refactored accordingly.